### PR TITLE
001 bar library

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
         "ranges": "cpp",
         "cstddef": "cpp",
         "matrix.h": "c",
-        "quaternion.h": "c"
+        "quaternion.h": "c",
+        "spi.h": "c"
     }
 }

--- a/Core/Inc/MS5607.h
+++ b/Core/Inc/MS5607.h
@@ -1,0 +1,176 @@
+/* ============================================================================================
+ MS5607-02 device SPI library code for ARM STM32F103xx is placed under the MIT
+license Copyright (c) 2020 João Pedro Vilas Boas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ ================================================================================================
+ */
+
+#ifndef __MS5607_H__
+#define __MS5607_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "spi.h"
+#include "stm32f4xx_hal.h"
+
+/* MS5607 SPI COMMANDS */
+#define RESET_COMMAND 0x1E
+#define PROM_READ(address)                                                     \
+  (0xA0 | ((address) << 1)) // Macro to change values for the 8 PROM addresses
+#define CONVERT_D1_COMMAND 0x40
+#define CONVERT_D2_COMMAND 0x50
+#define READ_ADC_COMMAND 0x00
+
+/* MS5607 Oversampling Ratio Enumeration*/
+typedef enum OSRFactors {
+  OSR_256,
+  OSR_512 = 0x02,
+  OSR_1024 = 0x04,
+  OSR_2048 = 0x06,
+  OSR_4096 = 0x08
+} MS5607OSRFactors;
+
+/* MS5607 System States Enumeration*/
+typedef enum MS5607States {
+  MS5607_STATE_FAILED,
+  MS5607_STATE_READY
+} MS5607StateTypeDef;
+
+/* MS5607 PROM Data Structure */
+struct promData {
+  uint16_t reserved;
+  uint16_t sens;
+  uint16_t off;
+  uint16_t tcs;
+  uint16_t tco;
+  uint16_t tref;
+  uint16_t tempsens;
+  uint16_t crc;
+};
+
+/* Uncompensated digital Values */
+struct MS5607UncompensatedValues {
+  uint32_t pressure;
+  uint32_t temperature;
+};
+
+/* Actual readings */
+struct MS5607Readings {
+  int32_t pressure;
+  int32_t temperature;
+};
+
+/**
+ * @brief  Initializes MS5607 Sensor
+ * @param  SPI Handle address
+ * @param  GPIO Port Definition
+ * @param  GPIO Pin
+ * @retval Initialization status:
+ *           - 0 or MS5607_STATE_FAILED: Was not abe to communicate with sensor
+ *           - 1 or MS5607_STATE_READY: Sensor initialized OK and ready to use
+ */
+MS5607StateTypeDef MS5607_Init(SPI_HandleTypeDef *, GPIO_TypeDef *, uint16_t);
+
+/**
+ * @brief  Reads MS5607 PROM Content
+ * @note   Must be called only on device initialization
+ * @param  Address of promData structure instance
+ * @retval None
+ */
+void MS5607PromRead(struct promData *);
+
+/**
+ * @brief  Reads uncompensated content from the MS5607 ADC
+ * @note   Must be called before every convertion
+ * @param  Address of MS5607 UncompensatedValues Structure
+ * @retval None
+ */
+void MS5607UncompensatedRead(struct MS5607UncompensatedValues *);
+
+/**
+ * @brief  Converts uncompensated values into real world values using data from
+ * @ref    promData and @ref MS5607UncompensatedValues
+ * @note   Must be called after @ref MS5607UncompensatedRead
+ * @param  Address of MS5607UncompensatedValues Structure
+ * @param  Address of MS5607Readings Structure
+ * @retval None
+ */
+void MS5607Convert(struct MS5607UncompensatedValues *, struct MS5607Readings *);
+
+/**
+ * @brief  Updates the readings from the sensor
+ * @note   This function must be called each time you want new values from the
+ * sensor
+ * @param  None
+ * @retval None
+ */
+void MS5607Update(void);
+
+/**
+ * @brief  Gets the temperature reading from the last sensor update
+ * @note   This function must be called after an @ref MS5607Update()
+ * @param  None
+ * @retval Temperature in celsius
+ */
+double MS5607GetTemperatureC(void);
+
+/**
+ * @brief  Gets the pressure reading from the last sensor update
+ * @note   This function must be called after an @ref MS5607Update()
+ * @param  None
+ * @retval Pressure in Pascal
+ */
+int32_t MS5607GetPressurePa(void);
+
+/**
+ * @brief  Enables the chip select pin
+ * @param  None
+ * @retval None
+ */
+void enableCSB(void);
+
+/**
+ * @brief  Disables the chip select pin
+ * @param  None
+ * @retval None
+ */
+void disableCSB(void);
+
+/**
+ * @brief  Sets the temperature reading oversamplig ratio
+ * @param  OSR factor from 256 to 4096
+ * @retval None
+ */
+void MS5607SetTemperatureOSR(MS5607OSRFactors);
+
+/**
+ * @brief  Sets the pressure reading oversamplig ratio
+ * @param  OSR factor from 256 to 4096
+ * @retval None
+ */
+void MS5607SetPressureOSR(MS5607OSRFactors);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __MS5607_H__

--- a/Core/Src/MS5607.c
+++ b/Core/Src/MS5607.c
@@ -1,0 +1,236 @@
+/* ============================================================================================
+ MS5607-02 device SPI library code for ARM STM32F103xx is placed under the MIT
+license Copyright (c) 2020 João Pedro Vilas Boas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ ================================================================================================
+ */
+
+#include "MS5607.h"
+
+/* Private SPI Handler */
+static SPI_HandleTypeDef *_hspi;
+
+/* Private GPIO CS Pin Variables */
+static GPIO_TypeDef *_CS_GPIO_Port;
+static uint16_t _CS_Pin;
+
+/* SPI Transmission Data */
+static uint8_t SPITransmitData;
+
+/* Private OSR Instantiations */
+static uint8_t Pressure_OSR = OSR_256;
+static uint8_t Temperature_OSR = OSR_256;
+
+/* Private data holders */
+
+/* PROM data structure */
+static struct promData promData;
+/* Unconpensated values structure */
+static struct MS5607UncompensatedValues uncompValues;
+/* Compensated values structure */
+static struct MS5607Readings readings;
+
+/** Reset and prepare for general usage.
+ * This will reset the device and perform the PROM reading to find the
+ * conversion values and if the communication is working.
+ */
+MS5607StateTypeDef MS5607_Init(SPI_HandleTypeDef *hspix, GPIO_TypeDef *GPIOx,
+                               uint16_t GPIO_Pin) {
+  _hspi = hspix;
+  _CS_GPIO_Port = GPIOx;
+  _CS_Pin = GPIO_Pin;
+
+  enableCSB();
+  SPITransmitData = RESET_COMMAND;
+  HAL_SPI_Transmit(_hspi, &SPITransmitData, 1, 10);
+  HAL_Delay(3);
+  disableCSB();
+
+  MS5607PromRead(&promData);
+
+  if (promData.reserved == 0x00 || promData.reserved == 0xff)
+    return MS5607_STATE_FAILED;
+  else
+    return MS5607_STATE_READY;
+}
+
+/* Performs a reading on the devices PROM. */
+void MS5607PromRead(struct promData *prom) {
+  uint8_t address;
+  uint16_t *structPointer;
+
+  /* As the PROM is made of 8 16bit addresses I used a pointer for acessing the
+   * data structure */
+  structPointer = (uint16_t *)prom;
+
+  for (address = 0; address < 8; address++) {
+    SPITransmitData = PROM_READ(address);
+    enableCSB();
+    HAL_SPI_Transmit(_hspi, &SPITransmitData, 1, 10);
+    /* Receive two bytes at once and stores it directly at the structure */
+    HAL_SPI_Receive(_hspi, structPointer, 2, 10);
+    disableCSB();
+    structPointer++;
+  }
+
+  /* Byte swap on 16bit integers*/
+  structPointer = (uint16_t *)prom;
+  for (address = 0; address < 8; address++) {
+    uint8_t *toSwap = (uint8_t *)structPointer;
+    uint8_t secondByte = toSwap[0];
+    toSwap[0] = toSwap[1];
+    toSwap[1] = secondByte;
+    structPointer++;
+  }
+}
+
+/* Performs a reading on the devices PROM. */
+void MS5607UncompensatedRead(struct MS5607UncompensatedValues *uncompValues) {
+
+  /*Sensor reply data buffer*/
+  uint8_t reply[3];
+
+  enableCSB();
+  /* Assemble the conversion command based on previously set OSR */
+  SPITransmitData = CONVERT_D1_COMMAND | Pressure_OSR;
+  HAL_SPI_Transmit(_hspi, &SPITransmitData, 1, 10);
+
+  if (Pressure_OSR == 0x00)
+    HAL_Delay(1);
+  else if (Pressure_OSR == 0x02)
+    HAL_Delay(2);
+  else if (Pressure_OSR == 0x04)
+    HAL_Delay(3);
+  else if (Pressure_OSR == 0x06)
+    HAL_Delay(5);
+  else
+    HAL_Delay(10);
+
+  disableCSB();
+
+  /* Performs the reading of the 24 bits from the ADC */
+
+  enableCSB();
+
+  SPITransmitData = READ_ADC_COMMAND;
+  HAL_SPI_Transmit(_hspi, &SPITransmitData, 1, 10);
+  HAL_SPI_Receive(_hspi, reply, 3, 10);
+
+  disableCSB();
+
+  /* Tranfer the 24bits read into a 32bit int */
+  uncompValues->pressure = ((uint32_t)reply[0] << 16) |
+                           ((uint32_t)reply[1] << 8) | (uint32_t)reply[2];
+
+  enableCSB();
+
+  /* Assemble the conversion command based on previously set OSR */
+  SPITransmitData = CONVERT_D2_COMMAND | Temperature_OSR;
+  HAL_SPI_Transmit(_hspi, &SPITransmitData, 1, 10);
+
+  if (Temperature_OSR == 0x00)
+    HAL_Delay(1);
+  else if (Temperature_OSR == 0x02)
+    HAL_Delay(2);
+  else if (Temperature_OSR == 0x04)
+    HAL_Delay(3);
+  else if (Temperature_OSR == 0x06)
+    HAL_Delay(5);
+  else
+    HAL_Delay(10);
+
+  disableCSB();
+
+  enableCSB();
+
+  SPITransmitData = READ_ADC_COMMAND;
+  HAL_SPI_Transmit(_hspi, &SPITransmitData, 1, 10);
+  HAL_SPI_Receive(_hspi, reply, 3, 10);
+
+  disableCSB();
+
+  /* Assemble the conversion command based on previously set OSR */
+  uncompValues->temperature = ((uint32_t)reply[0] << 16) |
+                              ((uint32_t)reply[1] << 8) | (uint32_t)reply[2];
+}
+
+/* Performs the data conversion according to the MS5607 datasheet */
+void MS5607Convert(struct MS5607UncompensatedValues *sample,
+                   struct MS5607Readings *value) {
+  int32_t dT;
+  int32_t TEMP;
+  int64_t OFF;
+  int64_t SENS;
+
+  dT = sample->temperature - ((int32_t)(promData.tref << 8));
+
+  TEMP = 2000 + (((int64_t)dT * promData.tempsens) >> 23);
+
+  OFF = ((int64_t)promData.off << 17) + (((int64_t)promData.tco * dT) >> 6);
+  SENS = ((int64_t)promData.sens << 16) + (((int64_t)promData.tcs * dT) >> 7);
+
+  /**/
+  if (TEMP < 2000) {
+    int32_t T2 = ((int64_t)dT * (int64_t)dT) >> 31;
+    int32_t TEMPM = TEMP - 2000;
+    int64_t OFF2 = (61 * (int64_t)TEMPM * (int64_t)TEMPM) >> 4;
+    int64_t SENS2 = 2 * (int64_t)TEMPM * (int64_t)TEMPM;
+    if (TEMP < -1500) {
+      int32_t TEMPP = TEMP + 1500;
+      int32_t TEMPP2 = TEMPP * TEMPP;
+      OFF2 = OFF2 + (int64_t)15 * TEMPP2;
+      SENS2 = SENS2 + (int64_t)8 * TEMPP2;
+    }
+    TEMP -= T2;
+    OFF -= OFF2;
+    SENS -= SENS2;
+  }
+
+  value->pressure = ((((int64_t)sample->pressure * SENS) >> 21) - OFF) >> 15;
+  value->temperature = TEMP;
+}
+
+/* Performs the sensor reading updating the data structures */
+void MS5607Update(void) {
+  MS5607UncompensatedRead(&uncompValues);
+  MS5607Convert(&uncompValues, &readings);
+}
+
+/* Gets the temperature from the sensor reading */
+double MS5607GetTemperatureC(void) {
+  return (double)readings.temperature / (double)100.0;
+}
+
+/* Gets the pressure from the sensor reading */
+int32_t MS5607GetPressurePa(void) { return readings.pressure; }
+
+/* Sets the CS pin */
+void enableCSB(void) {
+  HAL_GPIO_WritePin(_CS_GPIO_Port, _CS_Pin, GPIO_PIN_RESET);
+}
+
+/* Sets the CS pin */
+void disableCSB(void) { HAL_GPIO_WritePin(_CS_GPIO_Port, _CS_Pin, GPIO_PIN_SET); }
+
+/* Sets the OSR for temperature */
+void MS5607SetTemperatureOSR(MS5607OSRFactors tOSR) { Temperature_OSR = tOSR; }
+
+/* Sets the OSR for pressure */
+void MS5607SetPressureOSR(MS5607OSRFactors pOSR) { Pressure_OSR = pOSR; }

--- a/Core/Src/testing.c
+++ b/Core/Src/testing.c
@@ -1,7 +1,10 @@
 #include "mini-test.h"
 
 #include "BNO055.h"
+#include "MS5607.h"
+
 #include "i2c.h"
+#include "spi.h"
 
 /**
  * Testing BNO055 IMU library.
@@ -18,9 +21,10 @@ void TEST_bno055_get_event_vect_linear_acc(void);
  * Testing MS5607 BAR library.
  */
 
-void TEST_ms5607_update(void);
-
-void TEST_ms5607_get_pressure_pa(void);
+void TEST_ms5607_generic_setup_pass(void);
+void TEST_ms5607_generic_setup_fail(void);
+void TEST_ms5607_repeated_get_pressure(void);
+void TEST_ms5607_repeated_get_temperature(void);
 
 /**
  * Register ALL tests to be run.
@@ -33,14 +37,17 @@ void REGISTER_TESTS_PASS(void) {
   TEST_bno055_get_event_vect_euler();
   TEST_bno055_get_event_vect_linear_acc();
 
-  TEST_ms5607_update();
-  TEST_ms5607_get_pressure_pa();
+  TEST_ms5607_generic_setup_pass();
+  TEST_ms5607_repeated_get_pressure();
+  TEST_ms5607_repeated_get_temperature();
 }
 
 void REGISTER_TESTS_FAIL(void) {
   // Register tests that are expected to fail
 
   TEST_bno055_get_generic_event_fail();
+
+  TEST_ms5607_generic_setup_fail();
 }
 
 /**
@@ -50,30 +57,104 @@ void REGISTER_TESTS_FAIL(void) {
 // Expected acceleration range (BNO055 range: ±4g, assuming raw values)
 #define ACC_MAX_VALUE 4000
 
-void bno055_generic_setup(void) {
-
-}
+void bno055_generic_setup(void) {}
 
 // Test: Read accelerometer X-axis successfully
-void TEST_bno055_get_generic_event_pass(void) {
-}
+void TEST_bno055_get_generic_event_pass(void) { bno055_generic_setup(); }
 
 // Test: Read accelerometer X-axis successfully
-void TEST_bno055_get_generic_event_fail(void) {
-
-}
+void TEST_bno055_get_generic_event_fail(void) { bno055_generic_setup(); }
 
 // Test: Read accelerometer X-axis successfully
-void TEST_bno055_get_event_vect_gyro(void) {
-
-}
+void TEST_bno055_get_event_vect_gyro(void) { bno055_generic_setup(); }
 
 // Test: Read accelerometer X-axis successfully
-void TEST_bno055_get_event_vect_euler(void) {
-
-}
+void TEST_bno055_get_event_vect_euler(void) { bno055_generic_setup(); }
 
 // Test: Read accelerometer X-axis successfully
-void TEST_bno055_get_event_vect_linear_acc(void) {
+void TEST_bno055_get_event_vect_linear_acc(void) { bno055_generic_setup(); }
 
+/**
+ * Testing MS5607 BAR library.
+ */
+
+#define MS5607_PRESSURE_MIN 60000  // Minimum expected pressure in Pa
+#define MS5607_PRESSURE_MAX 110000 // Maximum expected pressure in Pa
+#define MS5607_TEMP_MIN 5          // Minimum expected temperature in °C
+#define MS5607_TEMP_MAX 40         // Maximum expected temperature in °C
+
+void ms5607_clean_up(void) { (void)MS5607_Init(NULL, NULL, INFINITY); }
+
+void TEST_ms5607_generic_setup_pass(void) {
+  MS5607StateTypeDef init_state =
+      MS5607_Init(&hspi3, BAR_CS_GPIO_Port, BAR_CS_Pin);
+
+  TEST_ASSERT(init_state == MS5607_STATE_READY, __FILE__, __LINE__);
+  ms5607_clean_up();
+}
+
+// Test: Confirm bad init in case of bad SPI handle, bad GPIO port, bad PIN
+void TEST_ms5607_generic_setup_fail(void) {
+  // Bad SPI handle
+  MS5607StateTypeDef init_state =
+      MS5607_Init(NULL, BAR_CS_GPIO_Port, BAR_CS_Pin);
+  TEST_ASSERT(init_state == MS5607_STATE_FAILED, __FILE__, __LINE__);
+  ms5607_clean_up();
+
+  // Bad GPIO port
+  MS5607StateTypeDef init_state = MS5607_Init(&hspi3, NULL, BAR_CS_Pin);
+  TEST_ASSERT(init_state == MS5607_STATE_FAILED, __FILE__, __LINE__);
+  ms5607_clean_up();
+
+  // Bad PIN
+  MS5607StateTypeDef init_state =
+      MS5607_Init(&hspi3, BAR_CS_GPIO_Port, UINT16_MAX);
+  TEST_ASSERT(init_state == MS5607_STATE_FAILED, __FILE__, __LINE__);
+  ms5607_clean_up();
+}
+
+void TEST_ms5607_repeated_get_pressure(void) {
+  // NOTE: This test assumes average altitude and atmospheric conditions
+
+  MS5607_Init(&hspi3, BAR_CS_GPIO_Port, BAR_CS_Pin); // Assume good init
+
+  const uint8_t repetitions = 10;
+  const uint32_t wait_ms = 10; // Wait between repeated readings
+  uint32_t readings[10];
+
+  for (uint8_t i = 0; i < repetitions; i++) {
+    MS5607Update();
+    readings[i] = MS5607GetPressurePa();
+    HAL_Delay(wait_ms);
+  }
+
+  for (uint8_t i = 0; i < repetitions; i++) {
+    TEST_ASSERT(readings[i] >= MS5607_PRESSURE_MIN, __FILE__, __LINE__);
+    TEST_ASSERT(readings[i] <= MS5607_PRESSURE_MAX, __FILE__, __LINE__);
+  }
+
+  ms5607_clean_up();
+}
+
+void TEST_ms5607_repeated_get_temperature(void) {
+  // NOTE: This test assumes average room temperature during testing
+
+  MS5607_Init(&hspi3, BAR_CS_GPIO_Port, BAR_CS_Pin); // Assume good init
+
+  const uint8_t repetitions = 10;
+  const uint32_t wait_ms = 10; // Wait between repeated readings
+  float readings[10];
+
+  for (uint8_t i = 0; i < repetitions; i++) {
+    MS5607Update();
+    readings[i] = MS5607GetTemperatureC();
+    HAL_Delay(wait_ms);
+  }
+
+  for (uint8_t i = 0; i < repetitions; i++) {
+    TEST_ASSERT(readings[i] >= MS5607_TEMP_MIN, __FILE__, __LINE__);
+    TEST_ASSERT(readings[i] <= MS5607_TEMP_MAX, __FILE__, __LINE__);
+  }
+
+  ms5607_clean_up();
 }

--- a/Core/Src/testing.c
+++ b/Core/Src/testing.c
@@ -15,16 +15,26 @@ void TEST_bno055_get_event_vect_euler(void);
 void TEST_bno055_get_event_vect_linear_acc(void);
 
 /**
+ * Testing MS5607 BAR library.
+ */
+
+void TEST_ms5607_update(void);
+
+void TEST_ms5607_get_pressure_pa(void);
+
+/**
  * Register ALL tests to be run.
  */
 void REGISTER_TESTS_PASS(void) {
   // Register tests that are expected to pass
 
   TEST_bno055_get_generic_event_pass();
-
   TEST_bno055_get_event_vect_gyro();
   TEST_bno055_get_event_vect_euler();
   TEST_bno055_get_event_vect_linear_acc();
+
+  TEST_ms5607_update();
+  TEST_ms5607_get_pressure_pa();
 }
 
 void REGISTER_TESTS_FAIL(void) {


### PR DESCRIPTION
## Description

This PR introduces a library adapted to the STM32 HAL for the MS5607 barometric sensor. This sensor is mainly used in the flight computer to obtain a rough estimate of the altitude at which the rocket is.

## Testing

This PR includes simple tests that verify the functions that are considered to regularly run in the main code for the flight computer. The tests go over updating the MS5607 readings, converting temperature and altitude to Pa and C units respectively, and retrieving these data.